### PR TITLE
Remove generator to stream bulk update

### DIFF
--- a/aiocouchdb/v1/tests/test_database.py
+++ b/aiocouchdb/v1/tests/test_database.py
@@ -131,26 +131,15 @@ class DatabaseTestCase(utils.DatabaseTestCase):
         self.assert_request_called_with('POST', self.db.name, '_bulk_docs',
                                         data=Ellipsis)
         data = self.request.call_args[1]['data']
-        self.assertIsInstance(data, types.GeneratorType)
-        if self._test_target == 'mock':
-            # while aiohttp.request is mocked, the payload generator
-            # doesn't get used so we can check the real payload data.
-            self.assertEqual(b'{"docs": [{"_id": "foo"},{"_id": "bar"}]}',
-                             b''.join(data))
 
-    def test_bulk_docs_all_or_nothing(self):
-        yield from self.db.bulk_docs([{'_id': 'foo'}, {'_id': 'bar'}],
-                                     all_or_nothing=True)
-        self.assert_request_called_with('POST', self.db.name, '_bulk_docs',
-                                        data=Ellipsis)
-        data = self.request.call_args[1]['data']
-        self.assertIsInstance(data, types.GeneratorType)
         if self._test_target == 'mock':
             # while aiohttp.request is mocked, the payload generator
             # doesn't get used so we can check the real payload data.
-            self.assertEqual(b'{"all_or_nothing": true, "docs": '
-                             b'[{"_id": "foo"},{"_id": "bar"}]}',
-                             b''.join(data))
+            self.assertEqual({
+                'new_edits': True,
+                'all_or_nothing': False,
+                'docs': [{"_id": "foo"}, {"_id": "bar"}]
+            }, data)
 
     def test_bulk_docs_new_edits(self):
         yield from self.db.bulk_docs([{'_rev': '1-foo'}], new_edits=False)


### PR DESCRIPTION
The aiohttp FormData api expects the given data either a file like
object, multidict or (name, file) pairs, not a generator. The aiohttp
documention mentions streaming uploads using asynchronous generators
here:
https://docs.aiohttp.org/en/stable/client_quickstart.html#streaming-uploads

However we've decided against it, since the documents we're bulk
updating are passed and in memory already. Additionally, we expect
sending < 100 documents per bulk update and no funding is available for
maintenance at this point. Given these constraints, we decided to remove
the generator and simply pass the docs along to the API.